### PR TITLE
Correct mistake heat tracking

### DIFF
--- a/parallel-HAMSTER_forward/tracking.py
+++ b/parallel-HAMSTER_forward/tracking.py
@@ -350,7 +350,7 @@ def process_data_in_parallel(datesmidp,lonlat_source,lon,lat,qv,Delta_q,theta,De
   #Change units
   inv_density = 1000./997.#This transforms kg of water to mm
   cp = 1005.7 
-  dts = dt*60.*60.
+  dts = 24*60.*60.
   PFE = PFE*inv_density/areas
   PFE = np.nan_to_num(PFE)#mm
   if json.loads(config['FLAGS']['save_qfe'].lower()):


### PR DESCRIPTION
Before you make heat a daily sum, yet when you convert you (previously) used dt which is often 3 hours so this is corrected to 24 as we did the daily sum a few lines ahead of this